### PR TITLE
Support Swift 3

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,14 @@
 use_frameworks!
 
-pod 'RxSwift', '~> 2.3'
-pod 'RxCocoa', '~> 2.3'
+def shared_pods
+  pod 'RxSwift', '~> 3.0'
+  pod 'RxCocoa', '~> 3.0'
+end
+
+target "RxAVFoundation" do
+  shared_pods
+end
+
+target "RxAVFoundationTests" do
+  shared_pods
+end

--- a/RxAVFoundation.podspec
+++ b/RxAVFoundation.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Source/*.swift'
 
-  s.dependency 'RxSwift', '~> 2.3'
-  s.dependency 'RxCocoa', '~> 2.3'
+  s.dependency 'RxSwift', '~> 3.0'
+  s.dependency 'RxCocoa', '~> 3.0'
 end

--- a/RxAVFoundation.xcodeproj/project.pbxproj
+++ b/RxAVFoundation.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B005221C26302A7D1DB829E /* Pods_RxAVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43FBE769877BDF54C1822E2B /* Pods_RxAVFoundation.framework */; };
+		279D05486A14C865D144342D /* Pods_RxAVFoundationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 098BC579A11D1817664B064E /* Pods_RxAVFoundationTests.framework */; };
 		4040FFC11CB470100096BEC2 /* AVAsynchronousKeyValueLoading+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4040FFBA1CB470100096BEC2 /* AVAsynchronousKeyValueLoading+Rx.swift */; };
 		4040FFC21CB470100096BEC2 /* AVPlayer+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4040FFBB1CB470100096BEC2 /* AVPlayer+Rx.swift */; };
 		4040FFC31CB470100096BEC2 /* AVPlayerItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4040FFBC1CB470100096BEC2 /* AVPlayerItem+Rx.swift */; };
@@ -19,7 +21,6 @@
 		4040FFD91CB472420096BEC2 /* RxAVPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4040FFCD1CB470170096BEC2 /* RxAVPlayerTests.swift */; };
 		4040FFDA1CB472440096BEC2 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4040FFCE1CB470170096BEC2 /* TestHelpers.swift */; };
 		40B801681CAC6CF50009BF04 /* RxAVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40B8015D1CAC6CF50009BF04 /* RxAVFoundation.framework */; };
-		7A48D462F1A35F83E4D55EF9 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C53B1EBF9F5D20F7D4516B2 /* Pods.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,6 +34,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		098BC579A11D1817664B064E /* Pods_RxAVFoundationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RxAVFoundationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		290E081DBDD1292AFD059CAE /* Pods-RxAVFoundationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxAVFoundationTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RxAVFoundationTests/Pods-RxAVFoundationTests.release.xcconfig"; sourceTree = "<group>"; };
 		4040FFBA1CB470100096BEC2 /* AVAsynchronousKeyValueLoading+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVAsynchronousKeyValueLoading+Rx.swift"; sourceTree = "<group>"; };
 		4040FFBB1CB470100096BEC2 /* AVPlayer+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVPlayer+Rx.swift"; sourceTree = "<group>"; };
 		4040FFBC1CB470100096BEC2 /* AVPlayerItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVPlayerItem+Rx.swift"; sourceTree = "<group>"; };
@@ -48,9 +51,13 @@
 		4040FFCE1CB470170096BEC2 /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		40B8015D1CAC6CF50009BF04 /* RxAVFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxAVFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		40B801671CAC6CF50009BF04 /* RxAVFoundationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RxAVFoundationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		43FBE769877BDF54C1822E2B /* Pods_RxAVFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RxAVFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6E1B6D3872C51C561A816217 /* Pods-RxAVFoundation.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxAVFoundation.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RxAVFoundation/Pods-RxAVFoundation.debug.xcconfig"; sourceTree = "<group>"; };
+		79864B138EB173FF28F2C5C2 /* Pods-RxAVFoundationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxAVFoundationTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RxAVFoundationTests/Pods-RxAVFoundationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7C53B1EBF9F5D20F7D4516B2 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		96772486540662D1DE9E3D16 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		AB3252B24238415422CD70C1 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		AC831C13CDFBE4E27F6BA2D8 /* Pods-RxAVFoundation.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxAVFoundation.release.xcconfig"; path = "Pods/Target Support Files/Pods-RxAVFoundation/Pods-RxAVFoundation.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,7 +65,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7A48D462F1A35F83E4D55EF9 /* Pods.framework in Frameworks */,
+				0B005221C26302A7D1DB829E /* Pods_RxAVFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,6 +74,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				40B801681CAC6CF50009BF04 /* RxAVFoundation.framework in Frameworks */,
+				279D05486A14C865D144342D /* Pods_RxAVFoundationTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +133,8 @@
 			isa = PBXGroup;
 			children = (
 				7C53B1EBF9F5D20F7D4516B2 /* Pods.framework */,
+				43FBE769877BDF54C1822E2B /* Pods_RxAVFoundation.framework */,
+				098BC579A11D1817664B064E /* Pods_RxAVFoundationTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -134,6 +144,10 @@
 			children = (
 				96772486540662D1DE9E3D16 /* Pods.debug.xcconfig */,
 				AB3252B24238415422CD70C1 /* Pods.release.xcconfig */,
+				6E1B6D3872C51C561A816217 /* Pods-RxAVFoundation.debug.xcconfig */,
+				AC831C13CDFBE4E27F6BA2D8 /* Pods-RxAVFoundation.release.xcconfig */,
+				79864B138EB173FF28F2C5C2 /* Pods-RxAVFoundationTests.debug.xcconfig */,
+				290E081DBDD1292AFD059CAE /* Pods-RxAVFoundationTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -156,12 +170,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 40B801711CAC6CF50009BF04 /* Build configuration list for PBXNativeTarget "RxAVFoundation" */;
 			buildPhases = (
-				AF1DFC0AD3FD45F87297A9FF /* Check Pods Manifest.lock */,
+				AF1DFC0AD3FD45F87297A9FF /* [CP] Check Pods Manifest.lock */,
 				40B801581CAC6CF50009BF04 /* Sources */,
 				40B801591CAC6CF50009BF04 /* Frameworks */,
 				40B8015A1CAC6CF50009BF04 /* Headers */,
 				40B8015B1CAC6CF50009BF04 /* Resources */,
-				1B541FEE2EC17685F5035916 /* Copy Pods Resources */,
+				1B541FEE2EC17685F5035916 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -176,9 +190,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 40B801741CAC6CF50009BF04 /* Build configuration list for PBXNativeTarget "RxAVFoundationTests" */;
 			buildPhases = (
+				8EF14031D859DD1D54BB7B9A /* [CP] Check Pods Manifest.lock */,
 				40B801631CAC6CF50009BF04 /* Sources */,
 				40B801641CAC6CF50009BF04 /* Frameworks */,
 				40B801651CAC6CF50009BF04 /* Resources */,
+				1A402B926F42ECDE73D45585 /* [CP] Embed Pods Frameworks */,
+				1F5B6F6642CCF28AC0B05EA2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -197,14 +214,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = YayNext;
 				TargetAttributes = {
 					40B8015C1CAC6CF50009BF04 = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0810;
 					};
 					40B801661CAC6CF50009BF04 = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0810;
 					};
 				};
 			};
@@ -244,34 +263,79 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1B541FEE2EC17685F5035916 /* Copy Pods Resources */ = {
+		1A402B926F42ECDE73D45585 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RxAVFoundationTests/Pods-RxAVFoundationTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		AF1DFC0AD3FD45F87297A9FF /* Check Pods Manifest.lock */ = {
+		1B541FEE2EC17685F5035916 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RxAVFoundation/Pods-RxAVFoundation-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		1F5B6F6642CCF28AC0B05EA2 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RxAVFoundationTests/Pods-RxAVFoundationTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8EF14031D859DD1D54BB7B9A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		AF1DFC0AD3FD45F87297A9FF /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -326,8 +390,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -375,8 +441,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -396,6 +464,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -405,7 +474,7 @@
 		};
 		40B801721CAC6CF50009BF04 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 96772486540662D1DE9E3D16 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 6E1B6D3872C51C561A816217 /* Pods-RxAVFoundation.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
@@ -420,12 +489,13 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		40B801731CAC6CF50009BF04 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB3252B24238415422CD70C1 /* Pods.release.xcconfig */;
+			baseConfigurationReference = AC831C13CDFBE4E27F6BA2D8 /* Pods-RxAVFoundation.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
@@ -439,28 +509,33 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.YayNext.RxAVFoundation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
 		40B801751CAC6CF50009BF04 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 79864B138EB173FF28F2C5C2 /* Pods-RxAVFoundationTests.debug.xcconfig */;
 			buildSettings = {
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.YayNext.RxAVFoundationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		40B801761CAC6CF50009BF04 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 290E081DBDD1292AFD059CAE /* Pods-RxAVFoundationTests.release.xcconfig */;
 			buildSettings = {
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.YayNext.RxAVFoundationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Source/AVAsynchronousKeyValueLoading+Rx.swift
+++ b/Source/AVAsynchronousKeyValueLoading+Rx.swift
@@ -11,18 +11,18 @@ import AVFoundation
 import RxSwift
 import RxCocoa
 
-extension AVAsynchronousKeyValueLoading {
-    public func rx_loadValuesForKeys(keys: [String]) -> Observable<Void> {
+extension Reactive where Base: AVAsynchronousKeyValueLoading {
+    public func loadValuesForKeys(_ keys: [String]) -> Observable<Void> {
         return Observable.create { observer in
-            self.loadValuesAsynchronouslyForKeys(keys) {
+            self.base.loadValuesAsynchronously(forKeys: keys) {
                 // TODO: Test statusOfValueForKey for every key that was loaded and
                 // return some kind of error model if any keys failed to load
                 
-                observer.on(.Next(()))
-                observer.on(.Completed)
+                observer.onNext(())
+                observer.onCompleted()
             }
             
-            return NopDisposable.instance
+            return Disposables.create()
         }
     }
 }

--- a/Source/AVPlayerItem+Rx.swift
+++ b/Source/AVPlayerItem+Rx.swift
@@ -11,45 +11,44 @@ import AVFoundation
 import RxSwift
 import RxCocoa
 
-extension AVPlayerItem {
-    public var rx_status: Observable<AVPlayerItemStatus> {
-        return self.rx_observe(AVPlayerItemStatus.self, "status")
-            .map { $0 ?? .Unknown }
+extension Reactive where Base: AVPlayerItem {
+    public var status: Observable<AVPlayerItemStatus> {
+        return self.observe(AVPlayerItemStatus.self, #keyPath(AVPlayerItem.status))
+            .map { $0 ?? .unknown }
     }
     
-    public var rx_duration: Observable<CMTime> {
-        return self.rx_observe(CMTime.self, "duration")
-            .map { $0 ?? CMTime.zero }
+    public var duration: Observable<CMTime> {
+        return self.observe(CMTime.self, #keyPath(AVPlayerItem.duration))
+            .map { $0 ?? .zero }
     }
     
-    public var rx_error: Observable<NSError?> {
-        return self.rx_observe(NSError.self, "error")
+    public var error: Observable<NSError?> {
+        return self.observe(NSError.self, #keyPath(AVPlayerItem.error))
     }
     
-    public var rx_playbackLikelyToKeepUp: Observable<Bool> {
-        return self.rx_observe(Bool.self, "playbackLikelyToKeepUp")
+    public var playbackLikelyToKeepUp: Observable<Bool> {
+        return self.observe(Bool.self, #keyPath(AVPlayerItem.isPlaybackLikelyToKeepUp))
             .map { $0 ?? false }
     }
     
-    public var rx_playbackBufferFull: Observable<Bool> {
-        return self.rx_observe(Bool.self, "playbackBufferFull")
+    public var playbackBufferFull: Observable<Bool> {
+        return self.observe(Bool.self, #keyPath(AVPlayerItem.isPlaybackBufferFull))
             .map { $0 ?? false }
     }
     
-    public var rx_playbackBufferEmpty: Observable<Bool> {
-        return self.rx_observe(Bool.self, "playbackBufferEmpty")
+    public var playbackBufferEmpty: Observable<Bool> {
+        return self.observe(Bool.self, #keyPath(AVPlayerItem.isPlaybackBufferEmpty))
             .map { $0 ?? false }
     }
     
-    public var rx_didPlayToEnd: Observable<NSNotification> {
-        let ns = NSNotificationCenter.defaultCenter()
-        return ns.rx_notification(AVPlayerItemDidPlayToEndTimeNotification,
-                                  object: self)
+    public var didPlayToEnd: Observable<Notification> {
+        let ns = NotificationCenter.default
+        return ns.rx.notification(.AVPlayerItemDidPlayToEndTime, object: base)
     }
     
-    public var rx_loadedTimeRanges: Observable<[CMTimeRange]> {
-        return self.rx_observe([NSValue].self, "loadedTimeRanges")
+    public var loadedTimeRanges: Observable<[CMTimeRange]> {
+        return self.observe([NSValue].self, #keyPath(AVPlayerItem.loadedTimeRanges))
             .map { $0 ?? [] }
-            .map { values in values.map { $0.CMTimeRangeValue } }
+            .map { values in values.map { $0.timeRangeValue } }
     }
 }

--- a/Source/AVPlayerLayer+Rx.swift
+++ b/Source/AVPlayerLayer+Rx.swift
@@ -11,9 +11,9 @@ import AVFoundation
 import RxSwift
 import RxCocoa
 
-extension AVPlayerLayer {
-    public var rx_readyForDisplay: Observable<Bool> {
-        return self.rx_observe(Bool.self, "readyForDisplay")
+extension Reactive where Base: AVPlayerLayer {
+    public var readyForDisplay: Observable<Bool> {
+        return self.observe(Bool.self, #keyPath(AVPlayerLayer.readyForDisplay))
             .map { $0 ?? false }
     }
 }

--- a/Tests/RxAVAsynchronousKeyValueLoadingTests.swift
+++ b/Tests/RxAVAsynchronousKeyValueLoadingTests.swift
@@ -13,16 +13,16 @@ class RxAVAsynchronousKeyValueLoadingTests: XCTestCase {
     func testCallingLoadValuesForKeys_CallsTheAsynchronousLoadingFunction() {
         class MockAsset: AVURLAsset {
             var calledWithKeys: [String]!
-            private override func loadValuesAsynchronouslyForKeys(keys: [String], completionHandler handler: (() -> Void)?) {
+            fileprivate override func loadValuesAsynchronously(forKeys keys: [String], completionHandler handler: (() -> Void)?) {
                 self.calledWithKeys = keys
             }
         }
         
-        let asset = MockAsset(URL: NSURL.Test)
+        let asset = MockAsset(url: URL.test)
         
         let keys = ["duration"]
-        asset.rx_loadValuesForKeys(keys)
-            .subscribeNext { }
+        asset.rx.loadValuesForKeys(keys)
+            .subscribe(onNext: {})
             .dispose()
         
         XCTAssertEqual(asset.calledWithKeys, keys)
@@ -30,20 +30,20 @@ class RxAVAsynchronousKeyValueLoadingTests: XCTestCase {
     
     func testNextAndCompletedShouldBeEmitted_WhenCompletionIsCalled() {
         class MockAsset: AVURLAsset {
-            private override func loadValuesAsynchronouslyForKeys(keys: [String], completionHandler handler: (() -> Void)?) {
+            fileprivate override func loadValuesAsynchronously(forKeys keys: [String], completionHandler handler: (() -> Void)?) {
                 handler!()
             }
         }
         
-        let asset = MockAsset(URL: NSURL.Test)
+        let asset = MockAsset(url: URL.test)
         var nextCalled = false
         var completedCalled = false
         
         let keys = ["duration"]
-        let o = asset.rx_loadValuesForKeys(keys)
-        o.subscribeNext { nextCalled = true }
+        let o = asset.rx.loadValuesForKeys(keys)
+        o.subscribe(onNext: { nextCalled = true })
             .dispose()
-        o.subscribeCompleted() { completedCalled = true }
+        o.subscribe(onCompleted: { completedCalled = true })
             .dispose()
         
         XCTAssertTrue(nextCalled)

--- a/Tests/RxAVPlayerItemTests.swift
+++ b/Tests/RxAVPlayerItemTests.swift
@@ -11,34 +11,34 @@ import XCTest
 import AVFoundation
 
 class RxAVPlayerItemTests: XCTestCase {
-    let asset = AVURLAsset(URL: NSURL(string: "www.google.com")!)
+    let asset = AVURLAsset(url: URL(string: "www.google.com")!)
     
     //MARK: Status
     
     func testPlayerItem_ShouldAllowObservationOfStatus() {
         let sut = AVPlayerItem(asset: asset)
         var capturedStatus: AVPlayerItemStatus?
-        sut.rx_status
-            .subscribeNext { capturedStatus = $0 }
+        sut.rx.status
+            .subscribe(onNext: { capturedStatus = $0 })
             .dispose()
         
-        XCTAssertEqual(capturedStatus, AVPlayerItemStatus.Unknown)
+        XCTAssertEqual(capturedStatus, AVPlayerItemStatus.unknown)
     }
     
     func testPlayerItem_ShouldUpdateRxStatus() {
         class MockItem: AVPlayerItem {
-            private override var status: AVPlayerItemStatus {
-                return .ReadyToPlay
+            fileprivate override var status: AVPlayerItemStatus {
+                return .readyToPlay
             }
         }
         
         let sut = MockItem(asset: asset)
         var capturedStatus: AVPlayerItemStatus?
-        sut.rx_status
-            .subscribeNext { capturedStatus = $0 }
+        sut.rx.status
+            .subscribe(onNext: { capturedStatus = $0 })
             .dispose()
         
-        XCTAssertEqual(capturedStatus, AVPlayerItemStatus.ReadyToPlay)
+        XCTAssertEqual(capturedStatus, AVPlayerItemStatus.readyToPlay)
     }
     
     //MARK: Duration
@@ -46,11 +46,11 @@ class RxAVPlayerItemTests: XCTestCase {
     func testPlayerItem_ShouldAllowObservationOfDuration() {
         let sut = AVPlayerItem(asset: asset)
         var capturedDuration: CMTime?
-        sut.rx_duration
-            .subscribeNext { capturedDuration = $0 }
+        sut.rx.duration
+            .subscribe(onNext: { capturedDuration = $0 })
             .dispose()
         
-        XCTAssertTrue(CMTimeCompare(capturedDuration!, kCMTimeZero) == 0)
+        XCTAssertEqual(capturedDuration?.value, CMTimeValue.allZeros)
     }
 
     func testPlayerItem_ShouldUpdateRxDuration() {
@@ -58,15 +58,15 @@ class RxAVPlayerItemTests: XCTestCase {
             // Using flag to test because player item does something odd and doesn't
             // return our mocked 5 second duration even though it's accessed
             var durationChecked = false
-            private override var duration: CMTime {
+            fileprivate override var duration: CMTime {
                 durationChecked = true
                 return CMTime(seconds: 5, preferredTimescale: 1)
             }
         }
         
         let sut = MockItem(asset: asset)
-        sut.rx_duration
-            .subscribeNext { duration in }
+        sut.rx.duration
+            .subscribe(onNext: { duration in })
             .dispose()
         
         XCTAssertTrue(sut.durationChecked)
@@ -77,8 +77,8 @@ class RxAVPlayerItemTests: XCTestCase {
     func testPlayerItem_ShouldAllowObservationOfError() {
         let sut = AVPlayerItem(asset: asset)
         var capturedError: NSError?
-        sut.rx_error
-            .subscribeNext { capturedError = $0 }
+        sut.rx.error
+            .subscribe(onNext: { capturedError = $0 })
             .dispose()
         
         XCTAssertNil(capturedError)
@@ -86,18 +86,18 @@ class RxAVPlayerItemTests: XCTestCase {
     
     func testPlayerItem_ShouldUpdateRxError() {
         class MockItem: AVPlayerItem {
-            private override var error: NSError? {
-                return NSError.Test
+            fileprivate override var error: Error? {
+                return NSError.test
             }
         }
         
         let sut = MockItem(asset: asset)
         var capturedError: NSError?
-        sut.rx_error
-            .subscribeNext { capturedError = $0 }
+        sut.rx.error
+            .subscribe(onNext: { capturedError = $0 })
             .dispose()
         
-        XCTAssertEqual(capturedError, NSError.Test)
+        XCTAssertEqual(capturedError, NSError.test)
     }
     
     // MARK: PlaybackLikelyToKeepUp
@@ -105,8 +105,8 @@ class RxAVPlayerItemTests: XCTestCase {
     func testPlayerItem_ShouldAllowObservationOfPlaybackLikelyToKeepUp() {
         let sut = AVPlayerItem(asset: asset)
         var capturedFlag: Bool!
-        sut.rx_playbackLikelyToKeepUp
-            .subscribeNext { capturedFlag = $0 }
+        sut.rx.playbackLikelyToKeepUp
+            .subscribe(onNext: { capturedFlag = $0 })
             .dispose()
         
         XCTAssertFalse(capturedFlag)
@@ -114,15 +114,15 @@ class RxAVPlayerItemTests: XCTestCase {
     
     func testPlayerItem_ShouldUpdateRxPlaybackLikelyToKeepUp() {
         class MockItem: AVPlayerItem {
-            private override var playbackLikelyToKeepUp: Bool {
+            fileprivate override var isPlaybackLikelyToKeepUp: Bool {
                 return true
             }
         }
         
         let sut = MockItem(asset: asset)
         var capturedFlag: Bool!
-        sut.rx_playbackLikelyToKeepUp
-            .subscribeNext { capturedFlag = $0 }
+        sut.rx.playbackLikelyToKeepUp
+            .subscribe(onNext: { capturedFlag = $0 })
             .dispose()
         
         XCTAssertTrue(capturedFlag)
@@ -133,8 +133,8 @@ class RxAVPlayerItemTests: XCTestCase {
     func testPlayerItem_ShouldAllowObservationOfPlaybackBufferFull() {
         let sut = AVPlayerItem(asset: asset)
         var capturedFlag: Bool!
-        sut.rx_playbackBufferFull
-            .subscribeNext { capturedFlag = $0 }
+        sut.rx.playbackBufferFull
+            .subscribe(onNext: { capturedFlag = $0 })
             .dispose()
         
         XCTAssertFalse(capturedFlag)
@@ -142,15 +142,15 @@ class RxAVPlayerItemTests: XCTestCase {
     
     func testPlayerItem_ShouldUpdateRxPlaybackBufferFull() {
         class MockItem: AVPlayerItem {
-            private override var playbackBufferFull: Bool {
+            fileprivate override var isPlaybackBufferFull: Bool {
                 return true
             }
         }
         
         let sut = MockItem(asset: asset)
         var capturedFlag: Bool!
-        sut.rx_playbackBufferFull
-            .subscribeNext { capturedFlag = $0 }
+        sut.rx.playbackBufferFull
+            .subscribe(onNext: { capturedFlag = $0 })
             .dispose()
         
         XCTAssertTrue(capturedFlag)
@@ -161,24 +161,24 @@ class RxAVPlayerItemTests: XCTestCase {
     func testPlayerItem_ShouldAllowObservationOfPlaybackBufferEmpty() {
         let sut = AVPlayerItem(asset: asset)
         var capturedFlag: Bool!
-        sut.rx_playbackBufferEmpty
-            .subscribeNext { capturedFlag = $0 }
+        sut.rx.playbackBufferEmpty
+            .subscribe(onNext: { capturedFlag = $0 })
             .dispose()
         
-        XCTAssertFalse(capturedFlag)
+        XCTAssertTrue(capturedFlag)
     }
     
     func testPlayerItem_ShouldUpdateRxPlaybackBufferEmpty() {
         class MockItem: AVPlayerItem {
-            private override var playbackBufferEmpty: Bool {
+            fileprivate override var isPlaybackBufferEmpty: Bool {
                 return true
             }
         }
         
         let sut = MockItem(asset: asset)
         var capturedFlag: Bool!
-        sut.rx_playbackBufferEmpty
-            .subscribeNext { capturedFlag = $0 }
+        sut.rx.playbackBufferEmpty
+            .subscribe(onNext: { capturedFlag = $0 })
             .dispose()
         
         XCTAssertTrue(capturedFlag)
@@ -189,8 +189,8 @@ class RxAVPlayerItemTests: XCTestCase {
     func testPlayerItem_ShouldAllowObservationOfDidReachEnd() {
         let sut = AVPlayerItem(asset: asset)
         var called: Bool = false
-        sut.rx_didPlayToEnd
-            .subscribeNext { note in called = true }
+        sut.rx.didPlayToEnd
+            .subscribe(onNext: { note in called = true })
             .dispose()
         
         XCTAssertFalse(called)
@@ -199,12 +199,11 @@ class RxAVPlayerItemTests: XCTestCase {
     func testPlayerItem_ShouldUpdateRxDidPlayToEnd() {
         let sut = AVPlayerItem(asset: asset)
         var called: Bool = false
-        let observer = sut.rx_didPlayToEnd
-            .subscribeNext { note in called = true }
+        let observer = sut.rx.didPlayToEnd
+            .subscribe(onNext: { note in called = true })
         
-        let ns = NSNotificationCenter.defaultCenter()
-        ns.postNotificationName(AVPlayerItemDidPlayToEndTimeNotification,
-                                object: sut)
+        let ns = NotificationCenter.default
+        ns.post(name: .AVPlayerItemDidPlayToEndTime, object: sut)
         
         observer.dispose()
         
@@ -216,8 +215,8 @@ class RxAVPlayerItemTests: XCTestCase {
     func testPlayerItem_ShouldAllowObservationOfLoadedTimeRanges() {
         let sut = AVPlayerItem(asset: asset)
         var capturedRanges: [CMTimeRange]?
-        sut.rx_loadedTimeRanges
-            .subscribeNext { capturedRanges = $0 }
+        sut.rx.loadedTimeRanges
+            .subscribe(onNext: { capturedRanges = $0 })
             .dispose()
         
         XCTAssertEqual(capturedRanges!, [])
@@ -226,15 +225,15 @@ class RxAVPlayerItemTests: XCTestCase {
     func testPlayerItem_WhenLoadedTimeRangesHasATimeRange_ShouldProduceThatRange() {
         class MockItem: AVPlayerItem {
             let range = CMTimeRange(start: CMTime.zero, duration: CMTime(seconds: 5, preferredTimescale: 1))
-            private override var loadedTimeRanges: [NSValue] {
-                return [NSValue(CMTimeRange: range)]
+            fileprivate override var loadedTimeRanges: [NSValue] {
+                return [NSValue(timeRange: range)]
             }
         }
         
         let sut = MockItem(asset: asset)
         var capturedRanges: [CMTimeRange]?
-        sut.rx_loadedTimeRanges
-            .subscribeNext { capturedRanges = $0 }
+        sut.rx.loadedTimeRanges
+            .subscribe(onNext: { capturedRanges = $0 })
             .dispose()
         
         XCTAssertEqual(capturedRanges!, [sut.range])

--- a/Tests/RxAVPlayerLayerTests.swift
+++ b/Tests/RxAVPlayerLayerTests.swift
@@ -14,8 +14,8 @@ class RxAVPlayerLayerTests: XCTestCase {
     func testPlayerLayer_ShouldAllowObservationOfReadyForDisplay() {
         let sut = AVPlayerLayer()
         var capturedFlag: Bool!
-        sut.rx_readyForDisplay
-            .subscribeNext { capturedFlag = $0 }
+        sut.rx.readyForDisplay
+            .subscribe(onNext: { capturedFlag = $0 })
             .dispose()
         
         XCTAssertFalse(capturedFlag)
@@ -35,7 +35,7 @@ class RxAVPlayerLayerTests: XCTestCase {
 //        
 //        let sut = MockLayer()
 //        var capturedFlag = false
-//        sut.rx_readyForDisplay
+//        sut.rx.readyForDisplay
 //            .subscribeNext { capturedFlag = $0 }
 //            .dispose()
 //        

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -9,13 +9,13 @@
 import Foundation
 
 extension NSError {
-    class var Test: NSError {
+    class var test: NSError {
         return NSError(domain: "test", code: 0, userInfo: nil)
     }
 }
 
-extension NSURL {
-    class var Test: NSURL {
-        return NSURL(string: "www.google.com")!
+extension URL {
+    static var test: URL {
+        return URL(string: "www.google.com")!
     }
 }


### PR DESCRIPTION
**This pull request contains breaking changes**

## Framework
* Convert codes to fit with Swift 3
* Apply recommended settings about compiler warnings
* Update `RxSwift` & `RxCocoa` versions to 3
* Migrate codes to follow convention of RxSwift 3 which contains adding extension for struct `Reactive` (`rx` property from object) instead of adding `rx_` prefix to respective methods
* Introduce `#keyPath` expression to avoid literal selector name

## Test
* Compare value of `CMTime` instead of itself to confirm initial duration is zero
* Change initial value of `isPlaybackBufferEmpty` as `true`