### PR TITLE
Add observer for currentItem

### DIFF
--- a/Source/AVPlayer+Rx.swift
+++ b/Source/AVPlayer+Rx.swift
@@ -16,6 +16,10 @@ extension Reactive where Base: AVPlayer {
         return self.observe(Float.self, #keyPath(AVPlayer.rate))
             .map { $0 ?? 0 }
     }
+
+    public var currentItem: Observable<AVPlayerItem?> {
+        return observe(AVPlayerItem.self, #keyPath(AVPlayer.currentItem))
+    }
     
     public var status: Observable<AVPlayerStatus> {
         return self.observe(AVPlayerStatus.self, #keyPath(AVPlayer.status))

--- a/Tests/RxAVPlayerTests.swift
+++ b/Tests/RxAVPlayerTests.swift
@@ -33,6 +33,31 @@ class RxAVPlayerRateTests: XCTestCase {
     }
 }
 
+class RxAVPlayerCurrentItemTests: XCTestCase {
+    let player = AVPlayer()
+    var capturedCurrentItem: AVPlayerItem?
+
+    func testObservingCurrentItem_ShouldReturnTheDefaultNilItem() {
+        player.rx.currentItem
+            .subscribe(onNext: { self.capturedCurrentItem = $0 })
+            .dispose()
+
+        XCTAssertNil(capturedCurrentItem)
+    }
+
+    func testObservingCurrentItem_ShouldReturnTheItemWhenSet() {
+        let url = URL(string: "https://example.com")
+        let item = AVPlayerItem(url: url!)
+        player.replaceCurrentItem(with: item)
+
+        player.rx.currentItem
+            .subscribe(onNext: { self.capturedCurrentItem = $0 })
+            .dispose()
+
+        XCTAssertEqual(capturedCurrentItem, item)
+    }
+}
+
 class RxAVPlayerStatusTests: XCTestCase {
     func testObservingStatus_ShouldReturnTheDefaultUnknown() {
         let player = AVPlayer()


### PR DESCRIPTION
This PR adds the observer for the AVPlayer `currentItem` property. Each time `replaceItem` is called then the observer will notify the subscribers with the new Item. 