### PR TITLE
Update spec to apply release candidate version of Rx-dependencies

### DIFF
--- a/RxAVFoundation.podspec
+++ b/RxAVFoundation.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Source/*.swift'
 
-  s.dependency 'RxSwift', '~> 3.0'
-  s.dependency 'RxCocoa', '~> 3.0'
+  s.dependency 'RxSwift', '~> 4.0-rc.0'
+  s.dependency 'RxCocoa', '~> 4.0-rc.0'
 end


### PR DESCRIPTION
Temporary update podspec for RxSwift `4.0.0-rc.0` can be used with repository based CocoaPods before formal release.

It will be better to have beta/rc version of `RxAVFoundation` itself.